### PR TITLE
Support Reasoning in anthropic and openai requests.  

### DIFF
--- a/llms/anthropic/anthropicllm.go
+++ b/llms/anthropic/anthropicllm.go
@@ -136,16 +136,30 @@ func generateMessagesContent(ctx context.Context, o *LLM, messages []llms.Messag
 	}
 
 	tools := toolsToTools(opts.Tools)
+	var thinking *anthropicclient.Thinking
+	temperature := &opts.Temperature
+	topP := &opts.TopP
+	if opts.Reasoning.IsEnabled && opts.Reasoning.Mode == llms.ReasoningModeTokens && opts.Reasoning.Tokens >= anthropicclient.MinThinkingTokens {
+		thinking = &anthropicclient.Thinking{
+			Type:         anthropicclient.Enabled,
+			BudgetTokens: opts.Reasoning.Tokens,
+		}
+		// Omit temperature and topP when thinking
+		temperature = nil
+		topP = nil
+	}
 	result, err := o.client.CreateMessage(ctx, &anthropicclient.MessageRequest{
-		Model:         opts.Model,
-		Messages:      chatMessages,
-		System:        systemPrompt,
-		MaxTokens:     opts.MaxTokens,
-		StopWords:     opts.StopWords,
-		Temperature:   opts.Temperature,
-		TopP:          opts.TopP,
-		Tools:         tools,
-		StreamingFunc: opts.StreamingFunc,
+		Model:                  opts.Model,
+		Messages:               chatMessages,
+		System:                 systemPrompt,
+		MaxTokens:              opts.MaxTokens,
+		StopWords:              opts.StopWords,
+		Temperature:            temperature,
+		TopP:                   topP,
+		Tools:                  tools,
+		StreamingFunc:          opts.StreamingFunc,
+		StreamingReasoningFunc: opts.StreamingReasoningFunc,
+		Thinking:               thinking,
 	})
 	if err != nil {
 		if o.CallbacksHandler != nil {

--- a/llms/anthropic/anthropicllm.go
+++ b/llms/anthropic/anthropicllm.go
@@ -139,7 +139,7 @@ func generateMessagesContent(ctx context.Context, o *LLM, messages []llms.Messag
 	var thinking *anthropicclient.Thinking
 	temperature := &opts.Temperature
 	topP := &opts.TopP
-	if opts.Reasoning.IsEnabled && opts.Reasoning.Mode == llms.ReasoningModeTokens && opts.Reasoning.Tokens >= anthropicclient.MinThinkingTokens {
+	if opts.Reasoning != nil && opts.Reasoning.IsEnabled && opts.Reasoning.Mode == llms.ReasoningModeTokens && opts.Reasoning.Tokens >= anthropicclient.MinThinkingTokens {
 		thinking = &anthropicclient.Thinking{
 			Type:         anthropicclient.Enabled,
 			BudgetTokens: opts.Reasoning.Tokens,

--- a/llms/anthropic/anthropicllm.go
+++ b/llms/anthropic/anthropicllm.go
@@ -148,13 +148,23 @@ func generateMessagesContent(ctx context.Context, o *LLM, messages []llms.Messag
 		topP = nil
 	}
 	if opts.Reasoning != nil && opts.Reasoning.IsEnabled && opts.Reasoning.Mode == llms.ReasoningModeTokens && opts.Reasoning.Tokens >= anthropicclient.MinThinkingTokens {
-		thinking = &anthropicclient.Thinking{
-			Type:         anthropicclient.Enabled,
-			BudgetTokens: opts.Reasoning.Tokens,
+		tokens := 0
+		if opts.MaxTokens != 0 {
+			if opts.Reasoning.Tokens < opts.MaxTokens {
+				tokens = opts.Reasoning.Tokens
+			} else {
+				tokens = opts.MaxTokens - 1
+			}
 		}
-		// Omit temperature and topP when thinking
-		temperature = nil
-		topP = nil
+		if tokens >= 1024 {
+			thinking = &anthropicclient.Thinking{
+				Type:         anthropicclient.Enabled,
+				BudgetTokens: tokens,
+			}
+			// Omit temperature and topP when thinking
+			temperature = nil
+			topP = nil
+		}
 	}
 	result, err := o.client.CreateMessage(ctx, &anthropicclient.MessageRequest{
 		Model:                  opts.Model,
@@ -179,12 +189,13 @@ func generateMessagesContent(ctx context.Context, o *LLM, messages []llms.Messag
 		return nil, ErrEmptyResponse
 	}
 
-	choices := make([]*llms.ContentChoice, len(result.Content))
-	for i, content := range result.Content {
+	choices := make([]*llms.ContentChoice, 0, len(result.Content))
+	reasoningContent := ""
+	for _, content := range result.Content {
 		switch content.GetType() {
 		case "text":
 			if textContent, ok := content.(*anthropicclient.TextContent); ok {
-				choices[i] = &llms.ContentChoice{
+				choice := &llms.ContentChoice{
 					Content:    textContent.Text,
 					StopReason: result.StopReason,
 					GenerationInfo: map[string]any{
@@ -192,8 +203,25 @@ func generateMessagesContent(ctx context.Context, o *LLM, messages []llms.Messag
 						"OutputTokens": result.Usage.OutputTokens,
 					},
 				}
+				if reasoningContent != "" {
+					// attach a reasoning to the text message and reset it.
+					choice.ReasoningContent = reasoningContent
+					reasoningContent = ""
+				}
+				choices = append(choices, choice)
 			} else {
 				return nil, fmt.Errorf("anthropic: %w for text message", ErrInvalidContentType)
+			}
+		case "thinking":
+			if thinkingContent, ok := content.(*anthropicclient.ThinkingContent); ok {
+				// save the thinking content and attach it to the next text as reasoning content
+				reasoningContent = thinkingContent.Thinking
+			} else {
+				return nil, fmt.Errorf("anthropic: %w for thinking content", ErrInvalidContentType)
+			}
+		case "redacted_thinking":
+			{
+				// NO handling for redacted thinking as of now
 			}
 		case "tool_use":
 			if toolUseContent, ok := content.(*anthropicclient.ToolUseContent); ok {
@@ -201,7 +229,7 @@ func generateMessagesContent(ctx context.Context, o *LLM, messages []llms.Messag
 				if err != nil {
 					return nil, fmt.Errorf("anthropic: failed to marshal tool use arguments: %w", err)
 				}
-				choices[i] = &llms.ContentChoice{
+				choice := &llms.ContentChoice{
 					ToolCalls: []llms.ToolCall{
 						{
 							ID: toolUseContent.ID,
@@ -217,6 +245,7 @@ func generateMessagesContent(ctx context.Context, o *LLM, messages []llms.Messag
 						"OutputTokens": result.Usage.OutputTokens,
 					},
 				}
+				choices = append(choices, choice)
 			} else {
 				return nil, fmt.Errorf("anthropic: %w for tool use message", ErrInvalidContentType)
 			}
@@ -224,7 +253,20 @@ func generateMessagesContent(ctx context.Context, o *LLM, messages []llms.Messag
 			return nil, fmt.Errorf("anthropic: %w: %v", ErrUnsupportedContentType, content.GetType())
 		}
 	}
-
+	// If there was a reasoning block without a subsequent text block, attach that as a separate choice
+	if reasoningContent != "" {
+		lastReasoningChoice := &llms.ContentChoice{
+			Content:    "",
+			StopReason: result.StopReason,
+			GenerationInfo: map[string]any{
+				"InputTokens":  result.Usage.InputTokens,
+				"OutputTokens": result.Usage.OutputTokens,
+			},
+			ReasoningContent: reasoningContent,
+		}
+		// Append to the slice. Worst case scenario slice will grow.
+		choices = append(choices, lastReasoningChoice)
+	}
 	resp := &llms.ContentResponse{
 		Choices: choices,
 	}

--- a/llms/anthropic/anthropicllm.go
+++ b/llms/anthropic/anthropicllm.go
@@ -139,6 +139,14 @@ func generateMessagesContent(ctx context.Context, o *LLM, messages []llms.Messag
 	var thinking *anthropicclient.Thinking
 	temperature := &opts.Temperature
 	topP := &opts.TopP
+	// Retain current behaviour of omitting zero values from payload.
+	// This is needed because as of now llms.CallOptions cannot really distinguish between 0 and absent values.
+	if opts.Temperature == 0 {
+		temperature = nil
+	}
+	if opts.TopP == 0 {
+		topP = nil
+	}
 	if opts.Reasoning != nil && opts.Reasoning.IsEnabled && opts.Reasoning.Mode == llms.ReasoningModeTokens && opts.Reasoning.Tokens >= anthropicclient.MinThinkingTokens {
 		thinking = &anthropicclient.Thinking{
 			Type:         anthropicclient.Enabled,

--- a/llms/anthropic/internal/anthropicclient/anthropicclient.go
+++ b/llms/anthropic/internal/anthropicclient/anthropicclient.go
@@ -127,29 +127,33 @@ type MessageRequest struct {
 	Model       string        `json:"model"`
 	Messages    []ChatMessage `json:"messages"`
 	System      string        `json:"system,omitempty"`
-	Temperature float64       `json:"temperature"`
+	Temperature *float64      `json:"temperature,omitempty"`
 	MaxTokens   int           `json:"max_tokens,omitempty"`
-	TopP        float64       `json:"top_p,omitempty"`
+	TopP        *float64      `json:"top_p,omitempty"`
 	Tools       []Tool        `json:"tools,omitempty"`
 	StopWords   []string      `json:"stop_sequences,omitempty"`
 	Stream      bool          `json:"stream,omitempty"`
+	Thinking    *Thinking     `json:"thinking,omitempty"`
 
-	StreamingFunc func(ctx context.Context, chunk []byte) error `json:"-"`
+	StreamingFunc          func(ctx context.Context, chunk []byte) error                 `json:"-"`
+	StreamingReasoningFunc func(ctx context.Context, reasoningChunk, chunk []byte) error `json:"-"`
 }
 
 // CreateMessage creates message for the messages api.
 func (c *Client) CreateMessage(ctx context.Context, r *MessageRequest) (*MessageResponsePayload, error) {
 	resp, err := c.createMessage(ctx, &messagePayload{
-		Model:         r.Model,
-		Messages:      r.Messages,
-		System:        r.System,
-		Temperature:   r.Temperature,
-		MaxTokens:     r.MaxTokens,
-		StopWords:     r.StopWords,
-		TopP:          r.TopP,
-		Tools:         r.Tools,
-		Stream:        r.Stream,
-		StreamingFunc: r.StreamingFunc,
+		Model:                  r.Model,
+		Messages:               r.Messages,
+		System:                 r.System,
+		Temperature:            r.Temperature,
+		MaxTokens:              r.MaxTokens,
+		StopWords:              r.StopWords,
+		TopP:                   r.TopP,
+		Tools:                  r.Tools,
+		Stream:                 r.Stream,
+		StreamingFunc:          r.StreamingFunc,
+		StreamingReasoningFunc: r.StreamingReasoningFunc,
+		Thinking:               r.Thinking,
 	})
 	if err != nil {
 		return nil, err

--- a/llms/anthropic/internal/anthropicclient/messages.go
+++ b/llms/anthropic/internal/anthropicclient/messages.go
@@ -14,19 +14,18 @@ import (
 )
 
 var (
-	ErrInvalidEventType                   = fmt.Errorf("invalid event type field type")
-	ErrInvalidMessageField                = fmt.Errorf("invalid message field type")
-	ErrInvalidUsageField                  = fmt.Errorf("invalid usage field type")
-	ErrInvalidIndexField                  = fmt.Errorf("invalid index field type")
-	ErrInvalidDeltaField                  = fmt.Errorf("invalid delta field type")
-	ErrInvalidDeltaTypeField              = fmt.Errorf("invalid delta type field type")
-	ErrInvalidDeltaTextField              = fmt.Errorf("invalid delta text field type")
-	ErrContentIndexOutOfRange             = fmt.Errorf("content index out of range")
-	ErrFailedCastToTextContent            = fmt.Errorf("failed to cast content to TextContent")
-	ErrInvalidDeltaThinkingField          = fmt.Errorf("invalid delta thinking field type")
-	ErrFailedCastToThinkingContent        = fmt.Errorf("failed to cast content to ThinkingContent")
-	ErrInvalidDeltaThinkingSignatureField = fmt.Errorf("invalid delta thinking signature field type")
-	ErrInvalidFieldType                   = fmt.Errorf("invalid field type")
+	ErrInvalidEventType            = fmt.Errorf("invalid event type field type")
+	ErrInvalidMessageField         = fmt.Errorf("invalid message field type")
+	ErrInvalidUsageField           = fmt.Errorf("invalid usage field type")
+	ErrInvalidIndexField           = fmt.Errorf("invalid index field type")
+	ErrInvalidDeltaField           = fmt.Errorf("invalid delta field type")
+	ErrInvalidDeltaTypeField       = fmt.Errorf("invalid delta type field type")
+	ErrInvalidDeltaTextField       = fmt.Errorf("invalid delta text field type")
+	ErrContentIndexOutOfRange      = fmt.Errorf("content index out of range")
+	ErrFailedCastToTextContent     = fmt.Errorf("failed to cast content to TextContent")
+	ErrInvalidDeltaThinkingField   = fmt.Errorf("invalid delta thinking field type")
+	ErrFailedCastToThinkingContent = fmt.Errorf("failed to cast content to ThinkingContent")
+	ErrInvalidFieldType            = fmt.Errorf("invalid field type")
 )
 
 type ChatMessage struct {
@@ -437,20 +436,7 @@ func handleContentBlockDeltaEvent(ctx context.Context, event map[string]interfac
 			return response, ErrFailedCastToThinkingContent
 		}
 		thinkingContent.Thinking += thinkingText
-	} else if deltaType == "signature_delta" {
-		signatureText, ok := delta["signature"].(string)
-		if !ok {
-			return response, ErrInvalidDeltaThinkingSignatureField
-		}
-		if len(response.Content) <= index {
-			return response, ErrContentIndexOutOfRange
-		}
-		thinkingContent, ok := response.Content[index].(*ThinkingContent)
-		if !ok {
-			return response, ErrFailedCastToThinkingContent
-		}
-		thinkingContent.Signature += signatureText
-	}
+	} // ignoring signature delta and redacted delta
 
 	if payload.StreamingFunc != nil && text != "" {
 		err := payload.StreamingFunc(ctx, []byte(text))

--- a/llms/anthropic/internal/anthropicclient/messages.go
+++ b/llms/anthropic/internal/anthropicclient/messages.go
@@ -14,21 +14,38 @@ import (
 )
 
 var (
-	ErrInvalidEventType        = fmt.Errorf("invalid event type field type")
-	ErrInvalidMessageField     = fmt.Errorf("invalid message field type")
-	ErrInvalidUsageField       = fmt.Errorf("invalid usage field type")
-	ErrInvalidIndexField       = fmt.Errorf("invalid index field type")
-	ErrInvalidDeltaField       = fmt.Errorf("invalid delta field type")
-	ErrInvalidDeltaTypeField   = fmt.Errorf("invalid delta type field type")
-	ErrInvalidDeltaTextField   = fmt.Errorf("invalid delta text field type")
-	ErrContentIndexOutOfRange  = fmt.Errorf("content index out of range")
-	ErrFailedCastToTextContent = fmt.Errorf("failed to cast content to TextContent")
-	ErrInvalidFieldType        = fmt.Errorf("invalid field type")
+	ErrInvalidEventType                   = fmt.Errorf("invalid event type field type")
+	ErrInvalidMessageField                = fmt.Errorf("invalid message field type")
+	ErrInvalidUsageField                  = fmt.Errorf("invalid usage field type")
+	ErrInvalidIndexField                  = fmt.Errorf("invalid index field type")
+	ErrInvalidDeltaField                  = fmt.Errorf("invalid delta field type")
+	ErrInvalidDeltaTypeField              = fmt.Errorf("invalid delta type field type")
+	ErrInvalidDeltaTextField              = fmt.Errorf("invalid delta text field type")
+	ErrContentIndexOutOfRange             = fmt.Errorf("content index out of range")
+	ErrFailedCastToTextContent            = fmt.Errorf("failed to cast content to TextContent")
+	ErrInvalidDeltaThinkingField          = fmt.Errorf("invalid delta thinking field type")
+	ErrFailedCastToThinkingContent        = fmt.Errorf("failed to cast content to ThinkingContent")
+	ErrInvalidDeltaThinkingSignatureField = fmt.Errorf("invalid delta thinking signature field type")
+	ErrInvalidFieldType                   = fmt.Errorf("invalid field type")
 )
 
 type ChatMessage struct {
 	Role    string      `json:"role"`
 	Content interface{} `json:"content"`
+}
+
+const MinThinkingTokens = 1024
+
+type ThinkingType string
+
+const (
+	Enabled  ThinkingType = "enabled"
+	Disabled ThinkingType = "disabled"
+)
+
+type Thinking struct {
+	Type         ThinkingType `json:"type"`
+	BudgetTokens int          `json:"budget_tokens"`
 }
 
 type messagePayload struct {
@@ -38,11 +55,13 @@ type messagePayload struct {
 	MaxTokens   int           `json:"max_tokens,omitempty"`
 	StopWords   []string      `json:"stop_sequences,omitempty"`
 	Stream      bool          `json:"stream,omitempty"`
-	Temperature float64       `json:"temperature"`
+	Temperature *float64      `json:"temperature,omitempty"`
 	Tools       []Tool        `json:"tools,omitempty"`
-	TopP        float64       `json:"top_p,omitempty"`
+	TopP        *float64      `json:"top_p,omitempty"`
+	Thinking    *Thinking     `json:"thinking,omitempty"`
 
-	StreamingFunc func(ctx context.Context, chunk []byte) error `json:"-"`
+	StreamingFunc          func(ctx context.Context, chunk []byte) error                 `json:"-"`
+	StreamingReasoningFunc func(ctx context.Context, reasoningChunk, chunk []byte) error `json:"-"`
 }
 
 // Tool used for the request message payload.
@@ -102,6 +121,25 @@ func (trc ToolResultContent) GetType() string {
 	return trc.Type
 }
 
+type ThinkingContent struct {
+	Type      string `json:"type"`
+	Thinking  string `json:"thinking"`
+	Signature string `json:"signature"`
+}
+
+func (thc ThinkingContent) GetType() string {
+	return thc.Type
+}
+
+type RedactedThinkingContent struct {
+	Type string `json:"type"`
+	Data string `json:"data"`
+}
+
+func (rthc RedactedThinkingContent) GetType() string {
+	return rthc.Type
+}
+
 type MessageResponsePayload struct {
 	Content      []Content `json:"content"`
 	ID           string    `json:"id"`
@@ -149,6 +187,18 @@ func (m *MessageResponsePayload) UnmarshalJSON(data []byte) error {
 				return err
 			}
 			m.Content = append(m.Content, tuc)
+		case "thinking":
+			thc := &ThinkingContent{}
+			if err := json.Unmarshal(raw, thc); err != nil {
+				return err
+			}
+			m.Content = append(m.Content, thc)
+		case "redacted_thinking":
+			rthc := &RedactedThinkingContent{}
+			if err := json.Unmarshal(raw, rthc); err != nil {
+				return err
+			}
+			m.Content = append(m.Content, rthc)
 		default:
 			return fmt.Errorf("unknown content type: %s\n%v", typeStruct.Type, string(raw))
 		}
@@ -178,7 +228,7 @@ func (c *Client) setMessageDefaults(payload *messagePayload) {
 	default:
 		payload.Model = defaultModel
 	}
-	if payload.StreamingFunc != nil {
+	if payload.StreamingFunc != nil || payload.StreamingReasoningFunc != nil {
 		payload.Stream = true
 	}
 }
@@ -201,7 +251,7 @@ func (c *Client) createMessage(ctx context.Context, payload *messagePayload) (*M
 		return nil, c.decodeError(resp)
 	}
 
-	if payload.StreamingFunc != nil {
+	if payload.StreamingFunc != nil || payload.StreamingReasoningFunc != nil {
 		return parseStreamingMessageResponse(ctx, resp, payload)
 	}
 
@@ -330,9 +380,15 @@ func handleContentBlockStartEvent(event map[string]interface{}, response Message
 	}
 
 	if len(response.Content) <= index {
-		response.Content = append(response.Content, &TextContent{
-			Type: eventType,
-		})
+		if eventType == "thinking" {
+			response.Content = append(response.Content, &ThinkingContent{
+				Type: eventType,
+			})
+		} else if eventType == "text" {
+			response.Content = append(response.Content, &TextContent{
+				Type: eventType,
+			})
+		} // There may be redated thinking blocks in content block start
 	}
 	return response, nil
 }
@@ -353,8 +409,10 @@ func handleContentBlockDeltaEvent(ctx context.Context, event map[string]interfac
 		return response, ErrInvalidDeltaTypeField
 	}
 
+	text := ""
+	thinkingText := ""
 	if deltaType == "text_delta" {
-		text, ok := delta["text"].(string)
+		text, ok = delta["text"].(string)
 		if !ok {
 			return response, ErrInvalidDeltaTextField
 		}
@@ -366,16 +424,44 @@ func handleContentBlockDeltaEvent(ctx context.Context, event map[string]interfac
 			return response, ErrFailedCastToTextContent
 		}
 		textContent.Text += text
+	} else if deltaType == "thinking_delta" {
+		thinkingText, ok = delta["thinking"].(string)
+		if !ok {
+			return response, ErrInvalidDeltaThinkingField
+		}
+		if len(response.Content) <= index {
+			return response, ErrContentIndexOutOfRange
+		}
+		thinkingContent, ok := response.Content[index].(*ThinkingContent)
+		if !ok {
+			return response, ErrFailedCastToThinkingContent
+		}
+		thinkingContent.Thinking += thinkingText
+	} else if deltaType == "signature_delta" {
+		signatureText, ok := delta["signature"].(string)
+		if !ok {
+			return response, ErrInvalidDeltaThinkingSignatureField
+		}
+		if len(response.Content) <= index {
+			return response, ErrContentIndexOutOfRange
+		}
+		thinkingContent, ok := response.Content[index].(*ThinkingContent)
+		if !ok {
+			return response, ErrFailedCastToThinkingContent
+		}
+		thinkingContent.Signature += signatureText
 	}
 
-	if payload.StreamingFunc != nil {
-		text, ok := delta["text"].(string)
-		if !ok {
-			return response, ErrInvalidDeltaTextField
-		}
+	if payload.StreamingFunc != nil && text != "" {
 		err := payload.StreamingFunc(ctx, []byte(text))
 		if err != nil {
 			return response, fmt.Errorf("streaming func returned an error: %w", err)
+		}
+	}
+	if payload.StreamingReasoningFunc != nil && (text != "" || thinkingText != "") {
+		err := payload.StreamingReasoningFunc(ctx, []byte(thinkingText), []byte(text))
+		if err != nil {
+			return response, fmt.Errorf("streaming reasoning func returned an error: %w", err)
 		}
 	}
 	return response, nil

--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -31,8 +31,8 @@ type StreamOptions struct {
 type ChatRequest struct {
 	Model       string         `json:"model"`
 	Messages    []*ChatMessage `json:"messages"`
-	Temperature float64        `json:"temperature"`
-	TopP        float64        `json:"top_p,omitempty"`
+	Temperature *float64       `json:"temperature,omitempty"`
+	TopP        *float64       `json:"top_p,omitempty"`
 	// Deprecated: Use MaxCompletionTokens
 	MaxTokens           int      `json:"-,omitempty"`
 	MaxCompletionTokens int      `json:"max_completion_tokens,omitempty"`
@@ -78,6 +78,9 @@ type ChatRequest struct {
 
 	// Metadata allows you to specify additional information that will be passed to the model.
 	Metadata map[string]any `json:"metadata,omitempty"`
+
+	// ReasoningEffort constrains effort on reasoning for reasoning models
+	ReasoningEffort llms.ReasoningLevel `json:"reasoning_effort,omitempty"`
 }
 
 // ToolType is the type of a tool.

--- a/llms/openai/internal/openaiclient/completions.go
+++ b/llms/openai/internal/openaiclient/completions.go
@@ -2,22 +2,26 @@ package openaiclient
 
 import (
 	"context"
+
+	"github.com/tmc/langchaingo/llms"
 )
 
 // CompletionRequest is a request to complete a completion.
 type CompletionRequest struct {
-	Model       string  `json:"model"`
-	Prompt      string  `json:"prompt"`
-	Temperature float64 `json:"temperature"`
+	Model       string   `json:"model"`
+	Prompt      string   `json:"prompt"`
+	Temperature *float64 `json:"temperature,omitempty"`
 	// Deprecated: Use MaxCompletionTokens
 	MaxTokens           int      `json:"-,omitempty"`
 	MaxCompletionTokens int      `json:"max_completion_tokens,omitempty"`
 	N                   int      `json:"n,omitempty"`
 	FrequencyPenalty    float64  `json:"frequency_penalty,omitempty"`
 	PresencePenalty     float64  `json:"presence_penalty,omitempty"`
-	TopP                float64  `json:"top_p,omitempty"`
+	TopP                *float64 `json:"top_p,omitempty"`
 	StopWords           []string `json:"stop,omitempty"`
 	Seed                int      `json:"seed,omitempty"`
+
+	ReasoningEffort llms.ReasoningLevel `json:"reasoning_effort,omitempty"`
 
 	// StreamingFunc is a function to be called for each chunk of a streaming response.
 	// Return an error to stop streaming early.
@@ -89,5 +93,6 @@ func (c *Client) createCompletion(ctx context.Context, payload *CompletionReques
 		PresencePenalty:     payload.PresencePenalty,
 		StreamingFunc:       payload.StreamingFunc,
 		Seed:                payload.Seed,
+		ReasoningEffort:     payload.ReasoningEffort,
 	})
 }

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -118,6 +118,14 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 	if opts.JSONMode {
 		req.ResponseFormat = ResponseFormatJSON
 	}
+	// Retain current behaviour of omitting zero values from payload.
+	// This is needed because as of now llms.CallOptions cannot really distinguish between 0 and absent values.
+	if opts.Temperature == 0 {
+		req.Temperature = nil
+	}
+	if opts.TopP == 0 {
+		req.TopP = nil
+	}
 	if opts.Reasoning != nil && opts.Reasoning.IsEnabled && opts.Reasoning.Mode == llms.ReasoningModeLevel && opts.Reasoning.Level != "" {
 		req.ReasoningEffort = opts.Reasoning.Level
 		// Omit temperature and topP when thinking

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -95,13 +95,15 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 
 		chatMsgs = append(chatMsgs, msg)
 	}
+
 	req := &openaiclient.ChatRequest{
 		Model:                  opts.Model,
 		StopWords:              opts.StopWords,
 		Messages:               chatMsgs,
 		StreamingFunc:          opts.StreamingFunc,
 		StreamingReasoningFunc: opts.StreamingReasoningFunc,
-		Temperature:            opts.Temperature,
+		Temperature:            &opts.Temperature,
+		TopP:                   &opts.TopP,
 		N:                      opts.N,
 		FrequencyPenalty:       opts.FrequencyPenalty,
 		PresencePenalty:        opts.PresencePenalty,
@@ -115,6 +117,12 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 	}
 	if opts.JSONMode {
 		req.ResponseFormat = ResponseFormatJSON
+	}
+	if opts.Reasoning.IsEnabled && opts.Reasoning.Mode == llms.ReasoningModeLevel && opts.Reasoning.Level != "" {
+		req.ReasoningEffort = opts.Reasoning.Level
+		// Omit temperature and topP when thinking
+		req.Temperature = nil
+		req.TopP = nil
 	}
 
 	// since req.Functions is deprecated, we need to use the new Tools API.

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -118,7 +118,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 	if opts.JSONMode {
 		req.ResponseFormat = ResponseFormatJSON
 	}
-	if opts.Reasoning.IsEnabled && opts.Reasoning.Mode == llms.ReasoningModeLevel && opts.Reasoning.Level != "" {
+	if opts.Reasoning != nil && opts.Reasoning.IsEnabled && opts.Reasoning.Mode == llms.ReasoningModeLevel && opts.Reasoning.Level != "" {
 		req.ReasoningEffort = opts.Reasoning.Level
 		// Omit temperature and topP when thinking
 		req.Temperature = nil

--- a/llms/options.go
+++ b/llms/options.go
@@ -69,7 +69,37 @@ type CallOptions struct {
 	// Supported MIME types are: text/plain: (default) Text output.
 	// application/json: JSON response in the response candidates.
 	ResponseMIMEType string `json:"response_mime_type,omitempty"`
+
+	// Reasoning constrains effort on reasoning for reasoning models
+	Reasoning *Reasoning `json:"reasoning,omitempty"`
 }
+
+type Reasoning struct {
+	IsEnabled bool           `json:"is_enabled"`
+	Mode      ReasoningMode  `json:"mode,omitempty"`
+	Level     ReasoningLevel `json:"level,omitempty"`
+	Tokens    int            `json:"tokens,omitempty"`
+}
+
+// ReasoningMode is the reasoning mode supported by the model.
+// OpenAI APIs support levels based reasoning, i.e "low", "medium", "high".
+// Anthropic supports allocating budget tokens (>1024) for reasoning.
+type ReasoningMode string
+
+const (
+	ReasoningModeLevel  ReasoningMode = "level"
+	ReasoningModeTokens ReasoningMode = "tokens"
+)
+
+// ReasoningLevel is the reasoning level to use for the model.
+// Defaults to "medium".
+type ReasoningLevel string
+
+const (
+	ReasoningLevelLow    ReasoningLevel = "low"
+	ReasoningLevelMedium ReasoningLevel = "medium"
+	ReasoningLevelHigh   ReasoningLevel = "high"
+)
 
 // Tool is a tool that can be used by the model.
 type Tool struct {
@@ -288,5 +318,12 @@ func WithMetadata(metadata map[string]interface{}) CallOption {
 func WithResponseMIMEType(responseMIMEType string) CallOption {
 	return func(o *CallOptions) {
 		o.ResponseMIMEType = responseMIMEType
+	}
+}
+
+// WithReasoning sets the reasoning object for the model, if it supports it.
+func WithReasoning(reasoning Reasoning) CallOption {
+	return func(o *CallOptions) {
+		o.Reasoning = &reasoning
 	}
 }


### PR DESCRIPTION

- Add Reasoning type that can be used by all LLMs to support reasoning. Add relevant flavors of reasoning types.
- Support Hybrid budget token based reasoning in anthropic.
- Support thinking content with and without streaming in anthropic.
- Support level based reasoning request in openai
- Need to make Temp and TopP optional in internal structs